### PR TITLE
Error Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ mongo-data/
 
 # VSCode
 .vscode/
+
+secrets/

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -3,5 +3,5 @@ import { CommandInteraction, SlashCommandBuilder, SlashCommandSubcommandsOnlyBui
 export interface Command {
     data: Omit<SlashCommandBuilder, "addSubcommandGroup" | "addSubcommand">
     | SlashCommandSubcommandsOnlyBuilder;
-    execute: (interaction: CommandInteraction) => Promise<void>
+    execute: (interaction: CommandInteraction) => Promise<void>;
 }

--- a/src/commands/set-channel.command.ts
+++ b/src/commands/set-channel.command.ts
@@ -1,28 +1,48 @@
-import { ChannelType, CommandInteraction, InteractionResponse, PermissionFlagsBits, SlashCommandBuilder } from "discord.js";
+import {
+  ChannelType,
+  CommandInteraction,
+  PermissionFlagsBits,
+  SlashCommandBuilder,
+} from "discord.js";
 import { Command } from "./command";
 import { commandNames } from "#core/constants/command-names.js";
 import { serverConfigRepository } from "#dals/server-config/repositories";
+import { checkChannelIsAccessible } from "#common/validations";
+
+const validateParams = (member, channel) => {
+  const errorMessage = checkChannelIsAccessible(member, channel);
+
+  if (errorMessage) throw new Error(errorMessage);
+};
 
 export const setChannelCommand: Command = {
-    data: new SlashCommandBuilder().setName(commandNames.setChannelCommandName)
-        .setDescription("Update notifications channel to the selected channel")
-        .addChannelOption((option) => option.setName("channel").setDescription("New channel for notifications").setRequired(true).addChannelTypes(ChannelType.GuildText))
-        .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+  data: new SlashCommandBuilder()
+    .setName(commandNames.setChannelCommandName)
+    .setDescription("Update notifications channel to the selected channel")
+    .addChannelOption((option) =>
+      option
+        .setName("channel")
+        .setDescription("New channel for notifications")
+        .setRequired(true)
+        .addChannelTypes(ChannelType.GuildText)
+    )
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
 
+  execute: async (interaction: CommandInteraction) => {
+    let content;
+    try {
+      const client = interaction.guild.members.me;
+      const channel = interaction.options.get("channel")?.channel;
+      validateParams(client, channel);
 
-    execute: async (interaction: CommandInteraction) => {
-        let content;
-        try {
-            const channel = interaction.options.get("channel")?.channel;
-            const { guildId } = interaction;
-            content = `Channel for notifications updated to #${channel?.name}`
+      const { guildId } = interaction;
 
-            serverConfigRepository.saveServerConfig(guildId, channel.id);
-        } catch (error) {
-            content = "There was an error updating the channel, make sure you've user /config first"
-        } finally {
-            interaction.reply({ content, ephemeral: true });
-        }
-
+      await serverConfigRepository.saveServerConfig(guildId, channel.id);
+      content = `Channel for notifications updated to #${channel?.name}`;
+    } catch (error) {
+      content = error.message;
+    } finally {
+      interaction.reply({ content, ephemeral: true });
     }
-}
+  },
+};

--- a/src/commands/set-config.command.ts
+++ b/src/commands/set-config.command.ts
@@ -1,25 +1,68 @@
-import { CommandInteraction, CacheType, SlashCommandBuilder, ChannelType, PermissionFlagsBits } from "discord.js";
+import {
+  CommandInteraction,
+  CacheType,
+  SlashCommandBuilder,
+  ChannelType,
+  PermissionFlagsBits,
+} from "discord.js";
 import { Command } from "./command";
 import { commandNames } from "#core/constants/command-names.js";
 import { serverConfigRepository } from "#dals/server-config/repositories";
+import {
+  checkChannelIsAccessible,
+  checkRoleCanBeMentioned,
+} from "#common/validations";
+
+const validateParams = (member, channel, role) => {
+  let errorMessage =
+    checkRoleCanBeMentioned(member, role) +
+    checkChannelIsAccessible(member, channel);
+
+  if (errorMessage) throw new Error(errorMessage);
+};
 
 export const setConfigCommand: Command = {
-    data: new SlashCommandBuilder()
-        .setName(commandNames.setConfigCommandName)
-        .setDescription("Creates and updates the configuration for the notification of scheduled events")
-        .addChannelOption((option) => option.setName("channel").setDescription("New channel for notifications").setRequired(true).addChannelTypes(ChannelType.GuildText))
-        .addRoleOption((role) => role.setRequired(true).setName("role").setDescription("New notification role that will be pinged when an event is created."))
-        .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+  data: new SlashCommandBuilder()
+    .setName(commandNames.setConfigCommandName)
+    .setDescription(
+      "Creates and updates the configuration for the notification of scheduled events"
+    )
+    .addChannelOption((option) =>
+      option
+        .setName("channel")
+        .setDescription("New channel for notifications")
+        .setRequired(true)
+        .addChannelTypes(ChannelType.GuildText)
+    )
+    .addRoleOption((role) =>
+      role
+        .setRequired(true)
+        .setName("role")
+        .setDescription(
+          "New notification role that will be pinged when an event is created."
+        )
+    )
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
 
-    execute: async (interaction: CommandInteraction<CacheType>) => {
-        const channel = interaction.options.get("channel")?.channel;
-        const role = interaction.options.get("role")?.role;
-        const content = `Notification channel and role succesfully changed. New values are #${channel.name} and ${role.name}`;
+  execute: async (interaction: CommandInteraction<CacheType>) => {
+    const client = interaction.guild.members.me;
+    const channel = interaction.options.get("channel")?.channel;
+    const role = interaction.options.get("role")?.role;
+    let content;
+    try {
+      validateParams(client, channel, role);
+      const { guildId } = interaction;
 
-        const { guildId } = interaction;
-
-        serverConfigRepository.saveServerConfig(guildId, channel.id, role.id);
-
-        interaction.reply({ content, ephemeral: true });
+      await serverConfigRepository.saveServerConfig(
+        guildId,
+        channel.id,
+        role.id
+      );
+      content = `Notification channel and role succesfully changed. New values are #${channel.name} and ${role.name}`;
+    } catch (e) {
+      content = e.message;
+    } finally {
+      interaction.reply({ content, ephemeral: true });
     }
-}
+  },
+};

--- a/src/common/validations/command.validations.ts
+++ b/src/common/validations/command.validations.ts
@@ -1,0 +1,13 @@
+import { APIRole, GuildMember, Role, TextChannel } from "discord.js"
+
+export const checkRoleCanBeMentioned = (member: GuildMember, role: Role | APIRole): string => {
+    return member.permissions.has("MentionEveryone") || role.mentionable ? "" :
+    `Bot can't mention given role ${role.name}. Make sure role is mentionable or that the bot has permissiones to mention all roles\n`;
+}
+
+export const checkChannelIsAccessible = (member: GuildMember, channel: TextChannel): string => {
+    return member.permissionsIn(channel).has("ViewChannel") && member.permissionsIn(channel).has("SendMessages") && member.permissionsIn(channel).has("EmbedLinks") ? "" : 
+    `Bot can't write or don't have access to the provided channel #${channel.name}. Please, review that bot has View Channel, Send Messages and Embed Links permissions on #${channel.name}`;
+}
+
+

--- a/src/common/validations/index.ts
+++ b/src/common/validations/index.ts
@@ -1,0 +1,1 @@
+export * from "./command.validations"

--- a/src/dals/server-config/repositories/server-config.db.repository.ts
+++ b/src/dals/server-config/repositories/server-config.db.repository.ts
@@ -5,6 +5,7 @@ import { ServerConfigRepository } from "./server-config.repository";
 
 export const serverConfigDBRepository: ServerConfigRepository = {
     getServerConfig: async (serverId: string) => await serverConfigContext.findOne({ serverId }).lean(),
+
     saveServerConfig: async (serverId: string, channelId?: string, roleId?: string) => {
         const serverConfig = await serverConfigContext.findOne<ServerConfig>({ serverId }) ??
         {
@@ -23,5 +24,10 @@ export const serverConfigDBRepository: ServerConfigRepository = {
             { upsert: true, returnDocument: "after" }
         ).lean();
         return updatedServerConfig;
+    },
+
+    deleteServerConfig: async (serverId: string) => {
+        const deletedRecords = await serverConfigContext.deleteMany({serverId}).lean()
+        return deletedRecords.deletedCount
     }
 }

--- a/src/dals/server-config/repositories/server-config.db.repository.ts
+++ b/src/dals/server-config/repositories/server-config.db.repository.ts
@@ -1,4 +1,3 @@
-import mongoose from "mongoose";
 import { serverConfigContext } from "../server-config.context";
 import { ServerConfig } from "../server-config.model";
 import { ServerConfigRepository } from "./server-config.repository";
@@ -14,6 +13,8 @@ export const serverConfigDBRepository: ServerConfigRepository = {
         serverConfig.notificationChannelId = channelId ?? serverConfig.notificationChannelId;
         serverConfig.notificationRoleId = roleId ?? serverConfig.notificationRoleId;
 
+        if(!(serverConfig.notificationChannelId && serverConfig.notificationRoleId)) throw new Error("This server has no config setup. Please, make sure to use /config first.")
+
         const updatedServerConfig = await serverConfigContext.findOneAndUpdate(
             {
                 serverId
@@ -27,7 +28,7 @@ export const serverConfigDBRepository: ServerConfigRepository = {
     },
 
     deleteServerConfig: async (serverId: string) => {
-        const deletedRecords = await serverConfigContext.deleteMany({serverId}).lean()
+        const deletedRecords = await serverConfigContext.deleteOne({serverId}).lean()
         return deletedRecords.deletedCount
     }
 }

--- a/src/dals/server-config/repositories/server-config.mock.repository.ts
+++ b/src/dals/server-config/repositories/server-config.mock.repository.ts
@@ -30,5 +30,6 @@ export const serverMockRepository: ServerConfigRepository = {
     getServerConfig: async (serverId: string) => db.serverConfigs.find(c => c.serverId === serverId),
     saveServerConfig: async (serverId: string, channelId?: string | undefined, roleId?: string | undefined) => db.serverConfigs.some(c => c.serverId === serverId) ?
         updateServerConfig(serverId, channelId, roleId) :
-        insertServerConfig(serverId, channelId, roleId)
+        insertServerConfig(serverId, channelId, roleId),
+    deleteServerConfig: async (serverId: string) => db.serverConfigs.splice(db.serverConfigs.findIndex(config => config.serverId === serverId), 1).length
 }

--- a/src/dals/server-config/repositories/server-config.repository.ts
+++ b/src/dals/server-config/repositories/server-config.repository.ts
@@ -3,4 +3,5 @@ import { ServerConfig } from "../server-config.model";
 export interface ServerConfigRepository {
     getServerConfig: (serverId: string) => Promise<ServerConfig>
     saveServerConfig: (serverId: string, channelId?: string, roleId?: string) => Promise<ServerConfig>
+    deleteServerConfig: (serverId: string) => Promise<number>
 }

--- a/src/handlers/guild.handler.ts
+++ b/src/handlers/guild.handler.ts
@@ -1,6 +1,9 @@
-import { deployCommandsSingleServer } from "#helpers";
+import { serverConfigRepository } from "#dals/server-config/repositories";
 import { Guild } from "discord.js";
 
-export const onGuildCreate = async (guild: Guild) => console.log("Hola");//deployCommandsSingleServer({ guildId: guild.id });
+export const onGuildCreate = async (guild: Guild) => console.log(`Joined ${guild.name}.`);
 
-export const onGuildDelete = async (guild: Guild) => console.log(`See you, ${guild.name}`)
+export const onGuildDelete = async (guild: Guild) => {
+    console.log(`See you, ${guild.name}`);
+    serverConfigRepository.deleteServerConfig(guild.id);
+}

--- a/src/handlers/scheduledEvent.handler.ts
+++ b/src/handlers/scheduledEvent.handler.ts
@@ -2,26 +2,25 @@ import { discordRestClient } from "#core/clients/discord-rest.client.js";
 import { serverConfigRepository } from "#dals/server-config/repositories";
 import { GuildScheduledEvent, REST, Routes } from "discord.js";
 
-export const onScheduledEventCreate = async (scheduledEvent: GuildScheduledEvent) => {
-    const { guildId, url } = scheduledEvent
+export const onScheduledEventCreate = async (
+  scheduledEvent: GuildScheduledEvent
+) => {
+  const { guildId, url } = scheduledEvent;
 
+  const serverConfig = await serverConfigRepository?.getServerConfig(guildId);
+  if (!serverConfig) return; //TODO Add error handler. Missing configuration
 
-    const { notificationChannelId, notificationRoleId } = await serverConfigRepository?.getServerConfig(guildId);
-    if (!notificationChannelId || !notificationRoleId) return; //TODO Add error handler. Missing configuration
+  const { notificationChannelId, notificationRoleId } = serverConfig;
 
-    const content = `<@&${notificationRoleId}> ${url}`
+  const content = `<@&${notificationRoleId}> ${url}`;
 
-    await discordRestClient.post(
-        Routes.channelMessages(notificationChannelId),
-        {
-            body: {
-                content,
-                allowedMentions: {
-                    parse: ["roles"],
-                    roles: [notificationRoleId]
-                }
-            }
-
-        }
-    )
-}
+  await discordRestClient.post(Routes.channelMessages(notificationChannelId), {
+    body: {
+      content,
+      allowedMentions: {
+        parse: ["roles"],
+        roles: [notificationRoleId],
+      },
+    },
+  });
+};


### PR DESCRIPTION
There was some errors in the application that causes that the bot to stop working, needing to be redeployed.

The fixes include:
- Setting the bot to a channel that can be accessed by the bot was allowed, but when trying to send the message it throws an unhandled error and stopped working.
- You could set a channel or a role and it would allow you. Then when trying to send the message it will throw an error and stopped working as there was data missing.
- If an event is created without having configured the bot, there's an unhandled error.